### PR TITLE
fix error with id provided as string

### DIFF
--- a/projects/kalidea/kaligraphi/src/lib/02-form/kal-checkbox/kal-checkbox.component.spec.ts
+++ b/projects/kalidea/kaligraphi/src/lib/02-form/kal-checkbox/kal-checkbox.component.spec.ts
@@ -1,10 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
+import { Component, DebugElement, NO_ERRORS_SCHEMA } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { KalCheckboxComponent } from 'projects/kalidea/kaligraphi/src/lib/02-form/kal-checkbox/kal-checkbox.component';
 import { FormElementComponent } from 'projects/kalidea/kaligraphi/src/lib/utils';
+import { KalCheckboxModule } from './kal-checkbox.module';
 
 describe('KalCheckboxComponent', () => {
   let component: KalCheckboxComponent;
@@ -120,5 +121,43 @@ describe('KalCheckboxComponent', () => {
     component.disabled = false;
 
     expect(component.control.disabled).toBeFalsy();
+  });
+
+});
+
+
+const checkboxId = 'my_checkbox';
+
+@Component({
+  selector: 'kal-test',
+  template: `<kal-checkbox id="${checkboxId}"></kal-checkbox>`
+})
+class TestComponent {
+
+}
+
+describe('KalCheckboxComponent with id provided', () => {
+  let fixture: ComponentFixture<TestComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [KalCheckboxModule],
+      declarations: [
+        TestComponent,
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+  });
+
+  it('should not duplicate id attribute', () => {
+    const HTMLElementsWithSameId = (fixture.nativeElement as HTMLElement).querySelectorAll('#' + checkboxId);
+    expect(HTMLElementsWithSameId.length).toEqual(1);
   });
 });

--- a/projects/kalidea/kaligraphi/src/lib/02-form/kal-checkbox/kal-checkbox.component.ts
+++ b/projects/kalidea/kaligraphi/src/lib/02-form/kal-checkbox/kal-checkbox.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  HostBinding,
   Input,
   OnChanges,
   OnDestroy,
@@ -34,6 +35,10 @@ export class KalCheckboxComponent extends FormElementComponent<boolean> implemen
    * Subscription of the valueChanges control
    */
   controlSubscription: Subscription;
+
+  // empty id attribute
+  @HostBinding('attr.id')
+  attributeId = null;
 
   private _value = false;
 


### PR DESCRIPTION
remove attribute id on kal-checkbox tag : when specified without binding :
 ```html
<kal-checkbox id="test label="checkbox"></kal-checkbox>
```

will now render
```html
<kal-checkbox disabled="false">
   <input type="checkbox" id="test">
      <label for="test">
          checkbox
         <span></span>
      </label>
</kal-checkbox>
 ```

instead of 

```html
<kal-checkbox disabled="false"  id="test">
   <input type="checkbox" id="test">
      <label for="test">
          checkbox
         <span></span>
      </label>
</kal-checkbox>
 ```