### PR TITLE
use dayjs plugins in production mode

### DIFF
--- a/src/app/02-form/form.module.ts
+++ b/src/app/02-form/form.module.ts
@@ -22,6 +22,13 @@ import { RaterComponent } from 'src/app/02-form/rater/rater.component';
 import { SelectComponent } from 'src/app/02-form/select/select.component';
 import { SliderComponent } from 'src/app/02-form/slider/slider.component';
 import { TextareaComponent } from 'src/app/02-form/textarea/textarea.component';
+import dayjs from 'dayjs';
+import localeData from 'dayjs/plugin/localeData';
+import weekday from 'dayjs/plugin/weekday';
+
+dayjs.extend(localeData);
+dayjs.extend(weekday);
+
 
 @NgModule({
   imports: [


### PR DESCRIPTION
dayjs plugins are removed from the library by ng-compilr
as a workaround we have to add the plugin in the application