### PR TITLE
fix KalAutofocus on KalInput

### DIFF
--- a/projects/kalidea/kaligraphi/src/lib/02-form/kal-input/kal-input.component.ts
+++ b/projects/kalidea/kaligraphi/src/lib/02-form/kal-input/kal-input.component.ts
@@ -6,6 +6,7 @@ import {
   ElementRef,
   EventEmitter,
   HostBinding,
+  HostListener,
   Inject,
   InjectionToken,
   Injector,
@@ -90,6 +91,10 @@ export class KalInputComponent extends FormElementComponent<string> implements O
   // empty id attribute
   @HostBinding('attr.id')
   attributeId = null;
+
+  // set tabindex to be able to receive focus event (KalAutoFocus)
+  @HostBinding('attr.tabindex')
+  tabIndex = 0;
 
   @AutoUnsubscribe()
   private controlValueChangedSubscription = Subscription.EMPTY;
@@ -185,8 +190,19 @@ export class KalInputComponent extends FormElementComponent<string> implements O
     }
   }
 
+  @HostListener('blur')
   blur() {
     this.inputElement.nativeElement.blur();
+    // set tabIndex back to 0 to be able to focus the kal-input again
+    this.tabIndex = 0
+  }
+
+  @HostListener('focus')
+  focus() {
+    this.inputElement.nativeElement.focus();
+    // set tabIndex to -1 to not trap the focus in the kal-input
+    // timeout to not trigger an error during angular render process
+    setTimeout(() => this.tabIndex = -1)
   }
 
   ngOnDestroy(): void {

--- a/projects/kalidea/kaligraphi/src/lib/99-utility/directives/kal-autofocus/kal-autofocus.directive.ts
+++ b/projects/kalidea/kaligraphi/src/lib/99-utility/directives/kal-autofocus/kal-autofocus.directive.ts
@@ -1,16 +1,18 @@
-import { Directive, ElementRef, Input, OnInit } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, Input } from '@angular/core';
+import { Coerce } from './../../../utils';
 
 @Directive({
   selector: '[kalAutofocus]'
 })
-export class KalAutofocusDirective implements OnInit {
+export class KalAutofocusDirective implements AfterViewInit {
 
+  @Coerce('boolean')
   @Input() kalAutofocus: boolean;
 
   constructor(private hostElement: ElementRef) {
   }
 
-  ngOnInit() {
+  ngAfterViewInit() {
     if (this.kalAutofocus) {
       this.hostElement.nativeElement.focus();
     }


### PR DESCRIPTION
KalAutoFocusDirective OnInit -> AfterViewInit to garantee that the component to focus is properly created

KalInput adding tabIndex and a focus function so that we become able to focus it with KalAutofocusDirective