### PR TITLE
bug fix for Kal-Autocomplete,

### DIFF
--- a/projects/kalidea/kaligraphi/src/lib/02-form/kal-autocomplete/kal-autocomplete-scroll-strategy.ts
+++ b/projects/kalidea/kaligraphi/src/lib/02-form/kal-autocomplete/kal-autocomplete-scroll-strategy.ts
@@ -1,9 +1,11 @@
-import { ScrollDispatcher, ScrollStrategy, ViewportRuler } from '@angular/cdk/overlay';
+import { ScrollDispatcher, ScrollStrategy } from '@angular/cdk/overlay';
 import { OverlayReference } from '@angular/cdk/overlay/overlay-reference';
 import { NgZone } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { CdkScrollable } from '@angular/cdk/scrolling/scrollable';
+
+import { KalAutocompleteComponent } from './kal-autocomplete.component';
 
 
 export class KalAutocompleteScrollStrategy implements ScrollStrategy {
@@ -20,7 +22,7 @@ export class KalAutocompleteScrollStrategy implements ScrollStrategy {
 
   detach(): void {
     this.disable();
-    this._overlayRef = null; //null!
+    this._overlayRef = null; // null!
   }
 
   disable(): void {
@@ -35,15 +37,19 @@ export class KalAutocompleteScrollStrategy implements ScrollStrategy {
       return;
     }
 
+
+    // @todo add threshold later if needed.
+    // when autocomplete is at bottom of the page: kal-autocomplete trigger a scroll event when positionning his overlay
+    // and that event close the autocomplete overlay
     this._scrollSubscription = this._scrollDispatcher.scrolled().pipe(
       tap((event: CdkScrollable) => {
-        if (!event?.getElementRef()?.nativeElement.classList?.contains('kal-autocomplete-scroll-viewport') && this._overlayRef.hasAttached()) {
+        if (event?.getElementRef()?.nativeElement.id !== KalAutocompleteComponent.id && this._overlayRef.hasAttached()) {
           this.disable();
           this._ngZone.run(() => this._overlayRef.detach());
         }
 
       })
-    ).subscribe()
+    ).subscribe();
   }
 
 }

--- a/projects/kalidea/kaligraphi/src/lib/02-form/kal-autocomplete/kal-autocomplete-scroll-strategy.ts
+++ b/projects/kalidea/kaligraphi/src/lib/02-form/kal-autocomplete/kal-autocomplete-scroll-strategy.ts
@@ -1,0 +1,49 @@
+import { ScrollDispatcher, ScrollStrategy, ViewportRuler } from '@angular/cdk/overlay';
+import { OverlayReference } from '@angular/cdk/overlay/overlay-reference';
+import { NgZone } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { CdkScrollable } from '@angular/cdk/scrolling/scrollable';
+
+
+export class KalAutocompleteScrollStrategy implements ScrollStrategy {
+  private _scrollSubscription: Subscription|null = null;
+  private _overlayRef: OverlayReference;
+
+  constructor(private _scrollDispatcher: ScrollDispatcher,
+              private _ngZone: NgZone) {
+  }
+
+  attach(overlayRef: OverlayReference): void {
+    this._overlayRef = overlayRef;
+  }
+
+  detach(): void {
+    this.disable();
+    this._overlayRef = null; //null!
+  }
+
+  disable(): void {
+    if (this._scrollSubscription) {
+      this._scrollSubscription.unsubscribe();
+      this._scrollSubscription = null;
+    }
+  }
+
+  enable(): void {
+    if (this._scrollSubscription) {
+      return;
+    }
+
+    this._scrollSubscription = this._scrollDispatcher.scrolled().pipe(
+      tap((event: CdkScrollable) => {
+        if (!event?.getElementRef()?.nativeElement.classList?.contains('kal-autocomplete-scroll-viewport') && this._overlayRef.hasAttached()) {
+          this.disable();
+          this._ngZone.run(() => this._overlayRef.detach());
+        }
+
+      })
+    ).subscribe()
+  }
+
+}

--- a/projects/kalidea/kaligraphi/src/lib/02-form/kal-autocomplete/kal-autocomplete.component.html
+++ b/projects/kalidea/kaligraphi/src/lib/02-form/kal-autocomplete/kal-autocomplete.component.html
@@ -10,7 +10,7 @@
   <ng-template #displayOptionsTemplate>
 
     <cdk-virtual-scroll-viewport
-      class="kal-autocomplete-scroll-viewport"
+      [id]="id"
       [itemSize]="virtualScrollConfig.itemSize"
       [style.height]="height">
 

--- a/projects/kalidea/kaligraphi/src/lib/02-form/kal-autocomplete/kal-autocomplete.component.html
+++ b/projects/kalidea/kaligraphi/src/lib/02-form/kal-autocomplete/kal-autocomplete.component.html
@@ -10,6 +10,7 @@
   <ng-template #displayOptionsTemplate>
 
     <cdk-virtual-scroll-viewport
+      class="kal-autocomplete-scroll-viewport"
       [itemSize]="virtualScrollConfig.itemSize"
       [style.height]="height">
 

--- a/projects/kalidea/kaligraphi/src/lib/02-form/kal-autocomplete/kal-autocomplete.component.ts
+++ b/projects/kalidea/kaligraphi/src/lib/02-form/kal-autocomplete/kal-autocomplete.component.ts
@@ -41,10 +41,14 @@ export const KAL_AUTOCOMPLETE_DATA = new InjectionToken<KalAutocompleteComponent
 })
 export class KalAutocompleteComponent<T> implements AfterViewInit, OnDestroy {
 
+  static readonly id = 'kal-autocomplete-scroll-viewport';
+
   /**
    * custom width of scroll container ( default to kal-input width )
    */
   width: string;
+
+  height: string;
 
   /**
    * custom of scroll container
@@ -64,8 +68,6 @@ export class KalAutocompleteComponent<T> implements AfterViewInit, OnDestroy {
    */
   private keyManager: ActiveDescendantKeyManager<KalOptionComponent>;
 
-  height: string;
-
   @AutoUnsubscribe()
   private subscription: Subscription;
 
@@ -74,6 +76,10 @@ export class KalAutocompleteComponent<T> implements AfterViewInit, OnDestroy {
     this.width = data.width;
     this.height = data.height;
     this.className = data.className;
+  }
+
+  get id() {
+    return KalAutocompleteComponent.id;
   }
 
   /**

--- a/projects/kalidea/kaligraphi/src/lib/02-form/kal-autocomplete/kal-autocomplete.directive.ts
+++ b/projects/kalidea/kaligraphi/src/lib/02-form/kal-autocomplete/kal-autocomplete.directive.ts
@@ -212,6 +212,7 @@ export class KalAutocompleteDirective<T = string> implements OnInit, OnDestroy {
 
   }
 
+  @HostListener('click')
   @HostListener('focusin')
   open() {
 

--- a/projects/kalidea/kaligraphi/src/lib/02-form/kal-autocomplete/kal-autocomplete.directive.ts
+++ b/projects/kalidea/kaligraphi/src/lib/02-form/kal-autocomplete/kal-autocomplete.directive.ts
@@ -4,6 +4,7 @@ import {
   Overlay,
   OverlayConfig,
   OverlayRef,
+  ScrollDispatcher,
   ScrollStrategy
 } from '@angular/cdk/overlay';
 import { ComponentPortal, PortalInjector } from '@angular/cdk/portal';
@@ -18,6 +19,7 @@ import {
   InjectionToken,
   Injector,
   Input,
+  NgZone,
   OnDestroy,
   OnInit,
   Optional,
@@ -39,6 +41,7 @@ import {
   KalAutocompleteComponentOption
 } from './kal-autocomplete.component';
 import { Coerce } from '../../utils/decorators/coerce';
+import { KalAutocompleteScrollStrategy } from './kal-autocomplete-scroll-strategy';
 
 
 @Directive({
@@ -99,6 +102,8 @@ export class KalAutocompleteDirective<T = string> implements OnInit, OnDestroy {
               private readonly input: KalInputComponent,
               private readonly elementRef: ElementRef<HTMLElement>,
               private readonly viewContainerRef: ViewContainerRef,
+              private _scrollDispatcher: ScrollDispatcher,
+              private _ngZone: NgZone,
               @Optional() @Host() private readonly theme: KalThemeDirective,
               @Optional() @Inject(DOCUMENT) private _document: any) {
 
@@ -146,7 +151,7 @@ export class KalAutocompleteDirective<T = string> implements OnInit, OnDestroy {
       const panelClass = this.theme ? this.theme.kalThemeAsClassNames : [''];
       const config: OverlayConfig = {
         positionStrategy: this.positionsList,
-        scrollStrategy: this.kalScrollStrategy || this.overlay.scrollStrategies.close(),
+        scrollStrategy: this.kalScrollStrategy || new KalAutocompleteScrollStrategy(this._scrollDispatcher, this._ngZone),
         panelClass: panelClass.concat('kal-overlay-autocomplete').join(' ').trim(),
         maxHeight: '90vh'
       };

--- a/src/app/02-form/autocomplete/autocomplete.component.ts
+++ b/src/app/02-form/autocomplete/autocomplete.component.ts
@@ -25,6 +25,13 @@ export class AutocompleteComponent implements OnDestroy {
     'Louis XV the Beloved',
     'Louis XVI the Restorer of French Liberty',
     'Napoleon I',
+    'Jean VI',
+    'Pierre Ier',
+    'Pierre II',
+    'Huangdi (黄帝)',
+    'Zhuanxu (颛顼)',
+    'Da Yu (大禹)',
+    'Zhong Kang (仲康)',
   ];
 
   clearOnPick = false;

--- a/src/app/app.component.sass
+++ b/src/app/app.component.sass
@@ -34,5 +34,3 @@
         color: #6a696b
         &:hover
           color: #f49231
-
-

--- a/src/styles.sass
+++ b/src/styles.sass
@@ -152,3 +152,9 @@ h1
   main
     flex: 1 1 auto
     padding: 40px 60px
+
+
+// add padding to test autocomplete close on scroll
+app-autocomplete
+  display: block
+  padding-bottom: 600px


### PR DESCRIPTION
The KalAutocomplete with close strategy prevented the scrolling inside his overlay.

Implementing a custom strategy that checks if the scroll occurs in the overlay to keep it open.