### PR TITLE
fix for the KalDialog afterClosed observable not completing

### DIFF
--- a/projects/kalidea/kaligraphi/src/lib/04-overlay/kal-dialog/kal-dialog-ref.ts
+++ b/projects/kalidea/kaligraphi/src/lib/04-overlay/kal-dialog/kal-dialog-ref.ts
@@ -90,6 +90,9 @@ export class KalDialogRef<T, D = any> {
    */
   private completeDialogClose() {
 
+    //complete afterClose subject
+    this.afterClosedSubject.complete()
+
     // close dialog
     this.kalDialogService.detachOverlay(this.overlayRef);
 


### PR DESCRIPTION
this will remove the need for take(1) when using afterClosed