### PR TITLE
Fix for KalRadio not responding on click on the label

### DIFF
--- a/projects/kalidea/kaligraphi/src/lib/02-form/kal-radio/kal-radio.component.html
+++ b/projects/kalidea/kaligraphi/src/lib/02-form/kal-radio/kal-radio.component.html
@@ -1,11 +1,12 @@
 <input
        type="radio"
+       [attr.id]="inputId"
        [name]="name"
        [checked]="checked"
        [value]="value"
        [disabled]="disabled"
        (change)="changeSelectedRadio($event)"/>
-<label [for]="id" [class.kal-radio__label--left]="labelPosition === 'before'">
+<label [for]="inputId" [class.kal-radio__label--left]="labelPosition === 'before'">
     <ng-content></ng-content>
 </label>
 <div></div>

--- a/projects/kalidea/kaligraphi/src/lib/02-form/kal-radio/kal-radio.component.spec.ts
+++ b/projects/kalidea/kaligraphi/src/lib/02-form/kal-radio/kal-radio.component.spec.ts
@@ -219,6 +219,7 @@ describe('Radio buttons inside a group with event', () => {
   let groupDebugElement;
   let radioDebugElements: DebugElement[];
   let radiosList: DebugElement[];
+  let radioLabelsList: DebugElement[];
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -247,6 +248,7 @@ describe('Radio buttons inside a group with event', () => {
     radioInstances = radioDebugElements.map(debugEl => debugEl.componentInstance);
 
     radiosList = fixture.debugElement.queryAll(By.css('input[type=radio]'));
+    radioLabelsList = fixture.debugElement.queryAll(By.css('label'));
 
   });
 
@@ -288,6 +290,30 @@ describe('Radio buttons inside a group with event', () => {
     expect(groupInstance.value).toEqual('test2');
 
     radiosList[2].nativeElement.click();
+
+    expect(component.displayValue).toHaveBeenCalledWith(new KalRadioChange(radioInstances[2], 'test3'));
+
+    expect(groupInstance.value).toEqual('test3');
+  });
+
+  it('should set the value when a radio label is clicked', () => {
+    spyOn(component, 'displayValue');
+
+    expect(groupInstance.value).toEqual('');
+
+    radioLabelsList[0].nativeElement.click();
+
+    expect(component.displayValue).toHaveBeenCalledWith(new KalRadioChange(radioInstances[0], 'test1'));
+
+    expect(groupInstance.value).toEqual('test1');
+
+    radioLabelsList[1].nativeElement.click();
+
+    expect(component.displayValue).toHaveBeenCalledWith(new KalRadioChange(radioInstances[1], 'test2'));
+
+    expect(groupInstance.value).toEqual('test2');
+
+    radioLabelsList[2].nativeElement.click();
 
     expect(component.displayValue).toHaveBeenCalledWith(new KalRadioChange(radioInstances[2], 'test3'));
 

--- a/projects/kalidea/kaligraphi/src/lib/02-form/kal-radio/kal-radio.component.ts
+++ b/projects/kalidea/kaligraphi/src/lib/02-form/kal-radio/kal-radio.component.ts
@@ -226,9 +226,9 @@ export class KalRadioComponent implements OnInit, OnDestroy {
   @Input() name: string;
 
   /**
-   * The unique id
+   * Id for the input element
    */
-  @Input() id = uniqid('kal-radio-button-id-');
+  inputId;
 
   /**
    * Triggered when the radio button value has changed
@@ -239,6 +239,11 @@ export class KalRadioComponent implements OnInit, OnDestroy {
    * The position of the label after or before the radio button. Defaults to after
    */
   labelRadioPosition: 'before' | 'after';
+
+  /**
+   * The unique id
+   */
+  private _id = uniqid('kal-radio-button-id-');
 
   /**
    * Is the radio button checked
@@ -334,7 +339,20 @@ export class KalRadioComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Mark for check on the raio button
+   * Id of the radio
+   */
+  @Input()
+  get id(): string {
+    return this._id
+  }
+
+  set id(id: string) {
+    this._id = id;
+    this.inputId = this._id  + '-input';
+  }
+
+  /**
+   * Mark for check on the radio button
    */
   markForCheck() {
     this.cdr.markForCheck();
@@ -372,6 +390,8 @@ export class KalRadioComponent implements OnInit, OnDestroy {
       this.name = this.radioGroup.name;
       this.checked = this.radioGroup.value === this.value;
     }
+
+    this.inputId = this._id + 'input';
   }
 
   ngOnDestroy() {

--- a/projects/kalidea/kaligraphi/src/lib/02-form/kal-radio/kal-radio.component.ts
+++ b/projects/kalidea/kaligraphi/src/lib/02-form/kal-radio/kal-radio.component.ts
@@ -343,7 +343,7 @@ export class KalRadioComponent implements OnInit, OnDestroy {
    */
   @Input()
   get id(): string {
-    return this._id
+    return this._id;
   }
 
   set id(id: string) {


### PR DESCRIPTION
 Fix for KalRadio not responding on click due to the absence of id on the inner input. preventing the event from the label from firing

added an id for the inner input to not have a duplicated id + a test to check if clicking on the label triggers the radio

correction for a regression from #340 