### PR TITLE
Fix missing space in form-fied template

### DIFF
--- a/projects/kalidea/kaligraphi/src/lib/02-form/kal-form-field/kal-form-field.component.html
+++ b/projects/kalidea/kaligraphi/src/lib/02-form/kal-form-field/kal-form-field.component.html
@@ -4,9 +4,7 @@
   <label [attr.for]="for"
          [class.kal-form-field--required]="required"
          class="kal-form-field__label">
-    <ng-container *ngIf="!labelTemplate else labelTemplate?.templateRef">
-      {{ label }}&nbsp;
-    </ng-container>
+    <ng-container *ngIf="!labelTemplate else labelTemplate?.templateRef">{{ label }}</ng-container>&nbsp;
   </label>
 
   <div *ngIf="legend" class="kal-form-field__legend">{{ legend }}</div>

--- a/src/app/02-form/form-field/form-field.component.html
+++ b/src/app/02-form/form-field/form-field.component.html
@@ -19,7 +19,6 @@
         <span>Input label with kalFormFieldLabelDirective</span>
         <kal-icon>settings</kal-icon>
       </div>
-      &nbsp;<br/>
     </ng-template>
 
     <kal-input [formControl]="control2"


### PR DESCRIPTION
when using `kalFormFieldLabelDirective` on required field, a space was missing between label and asterisk